### PR TITLE
update zabbix to 7.0.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zabbix/zabbix-proxy-sqlite3:alpine-7.0.25
+FROM zabbix/zabbix-proxy-sqlite3:alpine-7.0.26
 
 LABEL maintainer="mr.lioncub" \
       link1="https://github.com/zabbix/zabbix-docker/tree/7.0" \


### PR DESCRIPTION
Release Notes for Zabbix 7.0.26 → https://www.zabbix.com/rn/rn7.0.26